### PR TITLE
fix: resolve config before checking if SSR

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -30,16 +30,21 @@ function importBuild(options: {
   libraryName: string
 }): Plugin_ {
   let config: Config
+  let isSSR = false
   return {
     name: `@brillout/vite-plugin-import-build:${options.libraryName}`,
-    apply: (config, env) => env.command === 'build' && viteIsSSR(config),
+    apply: (_config, env) => env.command === 'build',
     configResolved(config_: ConfigPristine) {
+      isSSR = viteIsSSR(config_)
+      if (!isSSR) return
       config = resolveConfig(config_)
     },
     buildStart() {
+      if (!isSSR) return
       resetAutoImporter()
     },
     generateBundle(_rollupOptions, rollupBundle) {
+      if (!isSSR) return
       const emitFile = this.emitFile.bind(this)
       generateImporter(emitFile, rollupBundle)
     }


### PR DESCRIPTION
Testing SSR before config is resolved by Vite can return wrong values.
For example, since version `1.3.1` of SvelteKit, the SSR build process is executed with [`configFile`](https://vitejs.dev/guide/api-javascript.html#inlineconfig) property, which needs to be resolved in order to have the final `build.config.ssr` value.